### PR TITLE
Fix resume modal handlers not exposed globally

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1243,6 +1243,13 @@ function handleResumeGameSubmit(event) {
   saveCurrentGameState();
   showSaveIndicator("Starting scores set!");
 }
+
+// Ensure resume modal helpers are available to inline handlers
+if (typeof window !== "undefined") {
+  window.openResumeGameModal = openResumeGameModal;
+  window.closeResumeGameModal = closeResumeGameModal;
+  window.handleResumeGameSubmit = handleResumeGameSubmit;
+}
 function saveWinProbMethod() {
   const select = document.getElementById("winProbMethodSelect");
   if (select) {


### PR DESCRIPTION
## Summary
- expose the resume game modal helpers on the window object so inline handlers can access them
- keep the functions inert in non-browser environments by guarding the assignment

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbede971588327b1b76ef764e1d19a