### PR TITLE
Fix resume paper game button handler

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
         <li><button type="button" onclick="openSavedGamesModal(); toggleMenu(event);">View Games</button></li>
         <li><button type="button" onclick="handleNewGame(); toggleMenu(event);">New Game</button></li>
         <li><button type="button" onclick="handleFreezerGame(); toggleMenu(event);">Freeze Game</button></li>
-        <li><button type="button" onclick="openResumeGameModal(); toggleMenu(event);">Resume Paper Game</button></li>
+        <li><button type="button" id="resumePaperGameButton">Resume Paper Game</button></li>
         <li><button type="button" onclick="openSettingsModal(); toggleMenu(event);">Settings</button></li>
         <li><button type="button" onclick="openAboutModal(); toggleMenu(event);">About</button></li>
         <li><button type="button" onclick="openStatisticsModal(); toggleMenu(event);">Statistics</button></li>

--- a/js/app.js
+++ b/js/app.js
@@ -3904,6 +3904,14 @@ document.addEventListener("DOMContentLoaded", () => {
   document.getElementById("closeSavedGamesModalBtn")?.addEventListener("click", (e) => { e.stopPropagation(); closeSavedGamesModal(); });
   document.getElementById("teamSelectionForm")?.addEventListener("submit", handleTeamSelectionSubmit);
 
+  const resumePaperGameButton = document.getElementById("resumePaperGameButton");
+  if (resumePaperGameButton) {
+    resumePaperGameButton.addEventListener("click", (event) => {
+      openResumeGameModal();
+      toggleMenu(event);
+    });
+  }
+
   // Close modals on outside click (simplified)
   const modalCloseHandlers = {
     savedGamesModal: closeSavedGamesModal,


### PR DESCRIPTION
## Summary
- give the Resume Paper Game menu button a stable identifier
- bind the button click in JavaScript so the resume modal opens without relying on global scope

## Testing
- node --test tests/app.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e4188882508327958216a05aaed78a